### PR TITLE
Fix signature of main function

### DIFF
--- a/main.c
+++ b/main.c
@@ -41,7 +41,7 @@ void FreeResources() {
     DeinitWindow();
 }
 
-int main() {
+int main(int argc, char *argv[]) {
     if (!Initialize() || !LoadAssets()) return -1;
 
     StartGame();


### PR DESCRIPTION
On Windows, main function must have arguments (argc/argv).

```
D:/dev/t-rex-runner-c/main.c: In function 'SDL_main':
D:/dev/t-rex-runner-c/main.c:44:1: error: number of arguments doesn't match prototype
   44 | int main() {
      | ^~~
In file included from C:/msys64/mingw64/include/SDL2/SDL.h:32,
                 from D:/dev/t-rex-runner-c/sys/window.h:9,
                 from D:/dev/t-rex-runner-c/main.c:8:
C:/msys64/mingw64/include/SDL2/SDL_main.h:121:29: error: prototype declaration
  121 | extern SDLMAIN_DECLSPEC int SDL_main(int argc, char *argv[]);
      |                             ^~~~~~~~
make[2]: *** [CMakeFiles/trex_runner.dir/build.make:76: CMakeFiles/trex_runner.dir/main.c.obj] エラー 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/trex_runner.dir/all] エラー 2
make: *** [Makefile:91: all] エラー 2
```